### PR TITLE
Do not cache WebAuth Authentication block. Prevents strange redirects

### DIFF
--- a/webauth.module
+++ b/webauth.module
@@ -174,7 +174,7 @@ function webauth_block_info() {
     'pages'      => "user\nuser/*",
     'weight'     => 0,
     'region'     => 'sidebar_first',
-    'cache'      => DRUPAL_NO_CACHE,
+    'cache'      => DRUPAL_CACHE_PER_PAGE,
   );
   return $blocks;
 }


### PR DESCRIPTION
On sites with caching enabled, we have had a lot of user confusion about where they get redirected to after login. This alleviates that confusion by not caching the WMD login block (so the destination is always the current page).
