### PR TITLE
do not cache WMD login block

### DIFF
--- a/webauth.module
+++ b/webauth.module
@@ -174,7 +174,7 @@ function webauth_block_info() {
     'pages'      => "user\nuser/*",
     'weight'     => 0,
     'region'     => 'sidebar_first',
-    'cache'      => DRUPAL_CACHE_PER_PAGE,
+    'cache'      => DRUPAL_NO_CACHE,
   );
   return $blocks;
 }


### PR DESCRIPTION
This reverts commit 8f142cfc8dbd38640d37ba577013e0a477c9fdee.

Let's not cache this block at all :)
